### PR TITLE
Encoding: remove JSON encoding support

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,7 +2,6 @@ package etebase
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -67,6 +66,7 @@ func (c *Client) Post(path string, v interface{}) (*http.Response, error) {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/msgpack")
+	req.Header.Set("Accept", "application/msgpack")
 	if t := c.token; t != "" {
 		req.Header.Set("Authorization", "Token "+t)
 	}
@@ -125,7 +125,7 @@ func (acc *Account) Signup(user User, password string) error {
 
 	if resp.StatusCode != http.StatusCreated {
 		var respErr ErrorResponse
-		if err := json.NewDecoder(resp.Body).Decode(&respErr); err != nil {
+		if err := NewDecoder(resp.Body).Decode(&respErr); err != nil {
 			return err
 		}
 		return &respErr
@@ -147,7 +147,7 @@ func (acc *Account) loginChallenge(username string) (*LoginChallengeResponse, er
 		return nil, err
 	}
 	defer resp.Body.Close()
-	dec := json.NewDecoder(resp.Body)
+	dec := NewDecoder(resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
 		var rErr ErrorResponse
@@ -175,7 +175,7 @@ func (acc *Account) Login(username, password string) error {
 		return err
 	}
 
-	buf, err := msgpack.Marshal(&LoginRequest{
+	buf, err := Marshal(&LoginRequest{
 		Username:  username,
 		Challenge: challenge.Challenge,
 		Host:      "api.etebase.com",
@@ -197,7 +197,7 @@ func (acc *Account) Login(username, password string) error {
 	defer resp.Body.Close()
 
 	var loginResponse LoginResponse
-	if err := json.NewDecoder(resp.Body).Decode(&loginResponse); err != nil {
+	if err := NewDecoder(resp.Body).Decode(&loginResponse); err != nil {
 		return err
 	}
 	acc.token = loginResponse.Token
@@ -218,7 +218,7 @@ func (acc *Account) Play() error {
 	log.Printf("resp.Status = %+v\n", resp.Status)
 
 	var body interface{}
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+	if err := NewDecoder(resp.Body).Decode(&body); err != nil {
 		return err
 	}
 	log.Printf("body = %+v\n", body)

--- a/codec.go
+++ b/codec.go
@@ -1,0 +1,19 @@
+package etebase
+
+import (
+	"io"
+
+	"github.com/vmihailenco/msgpack"
+)
+
+type Decoder interface {
+	Decode(interface{}) error
+}
+
+func NewDecoder(r io.Reader) Decoder {
+	return msgpack.NewDecoder(r)
+}
+
+func Marshal(v interface{}) ([]byte, error) {
+	return msgpack.Marshal(v)
+}

--- a/types.go
+++ b/types.go
@@ -1,9 +1,7 @@
 package etebase
 
 import (
-	"encoding/base64"
 	"fmt"
-	"strings"
 )
 
 type User struct {
@@ -12,9 +10,9 @@ type User struct {
 }
 
 type ErrorResponse struct {
-	Code   string          `json:"code"`
-	Detail string          `json:"detail"`
-	Errors []ErrorResponse `json:"errors,omitempty"`
+	Code   string          `msgpack:"code"`
+	Detail string          `msgpack:"detail"`
+	Errors []ErrorResponse `msgpack:"errors,omitempty"`
 }
 
 func (err *ErrorResponse) Error() string {
@@ -29,23 +27,13 @@ type SignupRequest struct {
 	EncryptedContent []byte `msgpack:"encryptedContent"`
 }
 
-type Base64URL []byte
-
-func (b *Base64URL) UnmarshalJSON(data []byte) (err error) {
-	// remove '"' from the json data
-	str := strings.Trim(string(data), "\"")
-
-	*b, err = base64.RawURLEncoding.DecodeString(str)
-	return err
-}
-
 type LoginChallengeRequest struct {
 	Username string `msgpack:"username"`
 }
 
 type LoginChallengeResponse struct {
-	Salt      Base64URL `json:"salt"`
-	Challenge Base64URL `json:"challenge"`
+	Salt      []byte `msgpack:"salt"`
+	Challenge []byte `msgpack:"challenge"`
 }
 
 type LoginRequest struct {
@@ -56,10 +44,10 @@ type LoginRequest struct {
 }
 
 type LoginResponse struct {
-	Token string `json:"token"`
+	Token string `msgpack:"token"`
 	User  struct {
 		User
-		PubKey           string `json:"pubkey"`
-		EncryptedContent string `json:"encryptedContent"`
-	} `json:"user"`
+		PubKey           string `msgpack:"pubkey"`
+		EncryptedContent string `msgpack:"encryptedContent"`
+	} `msgpack:"user"`
 }


### PR DESCRIPTION
We were sending msgpack encoded request and receiving JSON encoded
responses from the server.

This PR adds the 'Accept: application/msgpack' HTTP header to receive
msgpack encoded responses.