### PR TITLE
Use the etesync test-server image for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,13 +20,12 @@ jobs:
       
       - name: Run local test Server
         run: |
-          docker pull victorrds/etebase
-          docker run -d -v $PWD/scripts:/etebase/scripts -e DEBUG=true -p 80:3735 victorrds/etebase ./scripts/testmode.sh
-          ./scripts/wait-for-it.sh localhost:80
+          docker run -d -p 3735:3735 etesync/test-server:latest
+          ./scripts/wait-for-it.sh localhost:3735
           
       - name: Tests
         env:
-          ETEBASE_TEST_HOST: localhost:80
+          ETEBASE_TEST_HOST: localhost:3735
         run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
       
       - name: Codecov

--- a/README.md
+++ b/README.md
@@ -23,6 +23,25 @@ A (work in progress) Go library for Etebase
 - [ ] Items
 - [ ] Invitations
 
+# Testing
+
+To test, run the `etesync/test-server` image using the latest version, e.g.,
+
+```
+docker run -p 3735:3735 -d etesync/test-server:latest
+```
+
+and then set `ETEBASE_TEST_HOST` to the host:port on which that is running; for the docker invocation above, that's
+```
+export ETEBASE_TEST_HOST=localhost:3735
+```
+
+and then run the tests
+
+```
+go test -v -v ./...
+```
+
 # Documentation
 
 In addition to the API documentation, there are docs available at https://docs.etebase.com

--- a/etebase_test.go
+++ b/etebase_test.go
@@ -23,6 +23,7 @@ type AccountSuite struct {
 }
 
 const (
+	// host, or host:port, on which the test server is running
 	hostEnv = "ETEBASE_TEST_HOST"
 )
 

--- a/scripts/testmode.sh
+++ b/scripts/testmode.sh
@@ -1,9 +1,0 @@
-# SPDX-FileCopyrightText: © 2020 Etebase Authors
-# SPDX-License-Identifier: BSD-3-Clause
-
-# testmode.sh is used to make :victorrds/etebase suitable to testing.
-# It enables the user signup via API
-sed -e '/ETEBASE_CREATE_USER_FUNC/ s/^#*/#/' -i etebase_server/settings.py
-
-./manage.py migrate
-./manage.py runserver 0.0.0.0:3735


### PR DESCRIPTION
See https://github.com/etesync/server/issues/94.

If that is merged and the image pushed to `etesync/test-server`, then I'll update the workflow here to use it, and this will be mergeable.