### PR TITLE
Security: use cryptographically secure random

### DIFF
--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -7,23 +7,19 @@ on:
       - master
       - main
   pull_request:
+permissions:
+  contents: read
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
+      - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.29
-
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
-
-          # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true

--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,10 @@ require (
 	golang.org/x/crypto v0.0.0-20201116153603-4be66e5b6582
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f // indirect
 )
+
+retract (
+	v0.1.0 // security: insecure random number generation, leading to predictable account keys
+	v0.0.3 // security: insecure random number generation, leading to predictable account keys
+	v0.0.2 // security: insecure random number generation, leading to predictable account keys
+	v0.0.1 // security: insecure random number generation, leading to predictable account keys
+)

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -4,17 +4,17 @@
 package crypto
 
 import (
-	"math/rand"
+	"crypto/rand"
 
 	"golang.org/x/crypto/argon2"
 	"golang.org/x/crypto/chacha20poly1305"
 	"golang.org/x/crypto/ed25519"
 )
 
-func Rand(len int) []byte {
+func Rand(len int) ([]byte, error) {
 	buf := make([]byte, len)
-	rand.Read(buf)
-	return buf
+	_, err := rand.Read(buf)
+	return buf, err
 }
 
 func DeriveKey(salt []byte, password string) []byte {

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -11,14 +11,22 @@ import (
 )
 
 func TestCryptoRand(t *testing.T) {
-	r1 := Rand(32)
-	r2 := Rand(32)
+	r1, err := Rand(32)
+	require.Nil(t, err)
+	r2, err := Rand(32)
+	require.Nil(t, err)
 	require.NotEqual(t, r1, r2)
+
+	// Ensure that Rand is not using unseeded math/rand
+	// Values taken from go1.19.4
+	require.NotEqual(t, r1, []byte{82, 253, 252, 7, 33, 130, 101, 79, 22, 63, 95, 15, 154, 98, 29, 114, 149, 102, 199, 77, 16, 3, 124, 77, 123, 187, 4, 7, 209, 226, 198, 73})
 }
 
 func TestCryptoDeriveKey(t *testing.T) {
+	r1, err := Rand(32)
+	require.Nil(t, err)
 	var (
-		rand = Rand(32)
+		rand = r1
 		pass = "password"
 	)
 
@@ -26,7 +34,9 @@ func TestCryptoDeriveKey(t *testing.T) {
 	key2 := DeriveKey(rand, pass)
 	require.Equal(t, key1, key2)
 
-	key3 := DeriveKey(Rand(32), pass)
+	r2, err := Rand(32)
+	require.Nil(t, err)
+	key3 := DeriveKey(r2, pass)
 	require.NotEqual(t, key1, key3)
 
 }


### PR DESCRIPTION
The old implementation used unseeded pseudo-random numbers, resulting in the exact same account key every time an
application was started. I've retracted old releases due to security problems.

Since the library in its current state is not that useful, I would guess that it wasn't used that much so the impact should be minimal.

If you want to test whether accounts were created using the old method (thus having predictable account keys), I've calcullated the first 100 salts that would have been used:
[salts.txt](https://github.com/etesync/etebase-go/files/10331606/salts.txt)

If you have any questions, do not hesitate to ask me here.
